### PR TITLE
✨ Add Label class and zone dimension display

### DIFF
--- a/app/editor.py
+++ b/app/editor.py
@@ -125,6 +125,7 @@ class Editor(Gtk.Layout):
         self._boundary_point_map = {Axis.x: {}, Axis.y: {}}
         self.visible_point: Optional[BoundPoint] = None
         self.boundaries = None
+        self._zones = None
 
         # Make the editor a drag destination
         self.drag_dest_set(Gtk.DestDefaults.ALL, [], Gdk.DragAction.MOVE)
@@ -185,6 +186,7 @@ class Editor(Gtk.Layout):
         point = Gtk.drag_get_source_widget(context)
         if point.is_valid_position(x, y):
             self.move(point, x, y)
+            self.label_zone_dimentions()
         return True
 
     def _set_visible_point(self, point: Optional[BoundPoint] = None):
@@ -198,6 +200,11 @@ class Editor(Gtk.Layout):
         if point:
             point.show()
         self.visible_point = point
+
+    def label_zone_dimentions(self):
+        for zone in self._zones:
+            width, height = zone.get_allocated_width(), zone.get_allocated_height()
+            zone.label.set_label(f'{width} x {height}')
 
     def move(self, widget: BoundPoint, x: int, y: int):
         """
@@ -265,6 +272,7 @@ class Editor(Gtk.Layout):
         :param zones: A list of Zone objects to set up the editor with.
         """
         self._clear()
+        self._zones = zones
         self.boundaries = self.create_boundaries(zones)
         for point in self.create_boundpoints(self.boundaries):
             self._boundary_point_map[point.boundary.axis][point.boundary] = point

--- a/app/zones.py
+++ b/app/zones.py
@@ -13,7 +13,7 @@ from shapely.geometry import LineString, Point
 from shapely.ops import linemerge, unary_union
 
 from .config import config
-from .widgets import Line
+from .widgets import Line, Label
 from .display import get_workarea
 from .base import Axis, Side, AbstractRectangleSide, Schema, TransparentApplicationWindow
 from .base import GtkStyleableMixin, SchemableMixin
@@ -44,7 +44,7 @@ class Zone(Gtk.Box, SchemableMixin, GtkStyleableMixin):
         """
         Gtk.Box.__init__(self)
         SchemableMixin.__init__(self, schema)
-        self.label = Gtk.Label()
+        self.label = Label()
         self.set_center_widget(self.label)
 
         # Declare the schema allocation object.
@@ -423,7 +423,6 @@ class ZoneContainer(Gtk.Fixed):
             schema.y += allocation.y
 
             # Label zones based on proximity to the origin from lower(closer) to higher(further).
-            zone.label.set_label(str(i+1))
             zone.size_allocate(schema.rectangle)
 
     def get_zone(self, x, y) -> Zone:

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -7,7 +7,7 @@
     "4": "Quarters",
     "6": "Six Zones"
   },
-  "default_preset": "Center Right Bias",
+  "default_preset": "Center Bias",
   "boundary-buffer-size": 100,
   "resource-prefix": "/org/linuxzones/app"
 }

--- a/settings/style.css
+++ b/settings/style.css
@@ -3,7 +3,7 @@
 .zone-pane {
     border: 1px solid #666666;
     font-family: sans-serif;
-    font-size: 25px;
+    font-size: 20px;
     color: #404040;
 }
 


### PR DESCRIPTION
✨ Create new Label class in widgets.py
- Replace Gtk.Widget usage in Zone
- Fine-tune allocation procedure control
- Allow text setting without triggering allocation
- Support existing CSS class styling

🚸 Improve UX with zone dimension display
- Add label_zone_dimensions() method in Editor
- Update label as user moves zone boundaries

(LZ-7)